### PR TITLE
Add exercise solutions

### DIFF
--- a/src/app/exercises/data-models-exercise/image.model.ts
+++ b/src/app/exercises/data-models-exercise/image.model.ts
@@ -1,0 +1,5 @@
+export interface Image {
+  id: number;
+  url: string;
+  description: string;
+}

--- a/src/app/exercises/data-models-exercise/image.service.ts
+++ b/src/app/exercises/data-models-exercise/image.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { Image } from './image.model';
+import { Observable, of } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class ImageService {
+  #images: Image[] = [
+    { id: 1, url: 'https://placekitten.com/200/200', description: 'Cute cat' },
+    { id: 2, url: 'https://placekitten.com/201/200', description: 'Another cat' }
+  ];
+
+  getImages(): Observable<Image[]> {
+    return of(this.#images);
+  }
+}

--- a/src/app/exercises/directives-exercise/hide-after.directive.ts
+++ b/src/app/exercises/directives-exercise/hide-after.directive.ts
@@ -1,0 +1,15 @@
+import { Directive, Input, HostListener, ElementRef } from '@angular/core';
+
+@Directive({
+  selector: '[hideAfter]'
+})
+export class HideAfterDirective {
+  @Input('hideAfter') delay = 5000;
+
+  constructor(private el: ElementRef<HTMLElement>) {}
+
+  @HostListener('click') onClick() {
+    const element = this.el.nativeElement;
+    setTimeout(() => element.style.display = 'none', this.delay);
+  }
+}

--- a/src/app/exercises/directives-exercise/index.ts
+++ b/src/app/exercises/directives-exercise/index.ts
@@ -1,0 +1,2 @@
+export * from './hide-after.directive';
+export * from './scroll-into-view.directive';

--- a/src/app/exercises/directives-exercise/scroll-into-view.directive.ts
+++ b/src/app/exercises/directives-exercise/scroll-into-view.directive.ts
@@ -1,0 +1,12 @@
+import { Directive, ElementRef, AfterViewInit } from '@angular/core';
+
+@Directive({
+  selector: '[scrollIntoView]'
+})
+export class ScrollIntoViewDirective implements AfterViewInit {
+  constructor(private el: ElementRef<HTMLElement>) {}
+
+  ngAfterViewInit(): void {
+    queueMicrotask(() => this.el.nativeElement.scrollIntoView());
+  }
+}

--- a/src/app/exercises/forms-exercise/travel-form.component.html
+++ b/src/app/exercises/forms-exercise/travel-form.component.html
@@ -1,0 +1,30 @@
+<form [formGroup]="form" (ngSubmit)="submit()">
+  <label>
+    Name
+    <input formControlName="name" />
+  </label>
+  <label>
+    Email
+    <input formControlName="email" />
+  </label>
+  <label>
+    Confirm Email
+    <input formControlName="confirmEmail" />
+  </label>
+  <label>
+    Origin Country
+    <input formControlName="origin" />
+  </label>
+  <label>
+    Destination Country
+    <input formControlName="dest" />
+  </label>
+  <label>
+    Israeli ID Number
+    <input formControlName="israelId" />
+  </label>
+  <button type="submit" [disabled]="form.invalid">Submit</button>
+</form>
+<div *ngIf="form.invalid && form.touched">
+  Form is invalid
+</div>

--- a/src/app/exercises/forms-exercise/travel-form.component.ts
+++ b/src/app/exercises/forms-exercise/travel-form.component.ts
@@ -1,0 +1,45 @@
+import { Component, inject } from '@angular/core';
+import { FormBuilder, Validators, ReactiveFormsModule, AbstractControl, ValidationErrors } from '@angular/forms';
+
+@Component({
+  selector: 'app-travel-form',
+  standalone: true,
+  imports: [ReactiveFormsModule],
+  templateUrl: './travel-form.component.html'
+})
+export class TravelFormComponent {
+  fb = inject(FormBuilder);
+
+  form = this.fb.group({
+    name: ['', Validators.required],
+    email: ['', [Validators.required, Validators.email]],
+    confirmEmail: ['', [Validators.required, Validators.email]],
+    dest: ['', Validators.required],
+    origin: ['', Validators.required],
+    israelId: ['', [Validators.required, this.israelIdValidator]]
+  }, { validators: this.matchEmail });
+
+  submit(): void {
+    if (this.form.valid) {
+      alert(JSON.stringify(this.form.value));
+    }
+  }
+
+  private matchEmail(group: AbstractControl): ValidationErrors | null {
+    const email = group.get('email')?.value;
+    const confirm = group.get('confirmEmail')?.value;
+    return email === confirm ? null : { emailMismatch: true };
+  }
+
+  private israelIdValidator(control: AbstractControl): ValidationErrors | null {
+    const id = control.value?.toString();
+    if (!id || id.length > 9 || !/^[0-9]+$/.test(id)) return { invalidId: true };
+    const padded = id.padStart(9, '0');
+    const sum = padded.split('').reduce((acc, num, idx) => {
+      let val = (+num) * ((idx % 2) + 1);
+      if (val > 9) val -= 9;
+      return acc + val;
+    }, 0);
+    return sum % 10 === 0 ? null : { invalidId: true };
+  }
+}

--- a/src/app/exercises/input-output-exercise/gallery.component.html
+++ b/src/app/exercises/input-output-exercise/gallery.component.html
@@ -1,0 +1,2 @@
+<img [src]="selected()" style="width:100%" />
+<app-image-list [images]="images" (selected)="select($event)"></app-image-list>

--- a/src/app/exercises/input-output-exercise/gallery.component.ts
+++ b/src/app/exercises/input-output-exercise/gallery.component.ts
@@ -1,0 +1,21 @@
+import { Component, signal } from '@angular/core';
+import { ImageListComponent } from './image-list.component';
+
+@Component({
+  selector: 'app-gallery',
+  standalone: true,
+  imports: [ImageListComponent],
+  templateUrl: './gallery.component.html'
+})
+export class GalleryComponent {
+  images = [
+    'https://placekitten.com/300/200',
+    'https://placekitten.com/301/200',
+    'https://placekitten.com/302/200'
+  ];
+  selected = signal(this.images[0]);
+
+  select(url: string) {
+    this.selected.set(url);
+  }
+}

--- a/src/app/exercises/input-output-exercise/image-list.component.html
+++ b/src/app/exercises/input-output-exercise/image-list.component.html
@@ -1,0 +1,3 @@
+<div style="display:flex; gap:8px">
+  <img *ngFor="let img of images" [src]="img" width="60" (click)="selected.emit(img)" style="cursor:pointer" />
+</div>

--- a/src/app/exercises/input-output-exercise/image-list.component.ts
+++ b/src/app/exercises/input-output-exercise/image-list.component.ts
@@ -1,0 +1,11 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'app-image-list',
+  standalone: true,
+  templateUrl: './image-list.component.html'
+})
+export class ImageListComponent {
+  @Input() images: string[] = [];
+  @Output() selected = new EventEmitter<string>();
+}

--- a/src/app/exercises/movie-explorer-exercise/duration.pipe.ts
+++ b/src/app/exercises/movie-explorer-exercise/duration.pipe.ts
@@ -1,0 +1,10 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'duration', standalone: true })
+export class DurationPipe implements PipeTransform {
+  transform(min: number): string {
+    const h = Math.floor(min / 60);
+    const m = min % 60;
+    return `${h}h ${m}m`;
+  }
+}

--- a/src/app/exercises/movie-explorer-exercise/movie-list.component.html
+++ b/src/app/exercises/movie-explorer-exercise/movie-list.component.html
@@ -1,0 +1,5 @@
+<div *ngFor="let m of movies$ | async" (click)="selectedId = m.id" [ngStyle]="{border: selectedId === m.id ? '2px solid blue' : 'none'}">
+  <img [src]="m.posterImage" width="80" />
+  <div>{{m.title}} - {{m.durationMinutes | duration}}</div>
+  <a [href]="m.imdbLink" target="_blank">IMDB</a>
+</div>

--- a/src/app/exercises/movie-explorer-exercise/movie-list.component.ts
+++ b/src/app/exercises/movie-explorer-exercise/movie-list.component.ts
@@ -1,0 +1,15 @@
+import { Component, inject } from '@angular/core';
+import { MovieService } from './movie.service';
+import { DurationPipe } from './duration.pipe';
+import { AsyncPipe, NgFor, NgIf } from '@angular/common';
+
+@Component({
+  selector: 'app-movie-list',
+  standalone: true,
+  imports: [NgFor, NgIf, AsyncPipe, DurationPipe],
+  templateUrl: './movie-list.component.html'
+})
+export class MovieListComponent {
+  movies$ = inject(MovieService).getMovies();
+  selectedId = 0;
+}

--- a/src/app/exercises/movie-explorer-exercise/movie.model.ts
+++ b/src/app/exercises/movie-explorer-exercise/movie.model.ts
@@ -1,0 +1,10 @@
+export interface Movie {
+  id: number;
+  title: string;
+  description: string;
+  posterImage: string;
+  imdbLink: string;
+  durationMinutes: number;
+  genre: string[];
+  rating: number;
+}

--- a/src/app/exercises/movie-explorer-exercise/movie.service.ts
+++ b/src/app/exercises/movie-explorer-exercise/movie.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { Movie } from './movie.model';
+import { Observable, of } from 'rxjs';
+
+const MOVIES: Movie[] = [
+  {
+    id: 1,
+    title: 'Inception',
+    description: 'Dream thieves.',
+    posterImage: 'https://m.media-amazon.com/images/I/51s+9xX7pqL._AC_.jpg',
+    imdbLink: 'https://www.imdb.com/title/tt1375666/',
+    durationMinutes: 148,
+    genre: ['Action','Sci-Fi'],
+    rating: 8.8
+  },
+  {
+    id: 2,
+    title: 'The Matrix',
+    description: 'What is real?',
+    posterImage: 'https://m.media-amazon.com/images/I/51EG732BV3L._AC_.jpg',
+    imdbLink: 'https://www.imdb.com/title/tt0133093/',
+    durationMinutes: 136,
+    genre: ['Action','Sci-Fi'],
+    rating: 8.7
+  }
+];
+
+@Injectable({ providedIn: 'root' })
+export class MovieService {
+  getMovies(): Observable<Movie[]> {
+    return of(MOVIES);
+  }
+}

--- a/src/app/exercises/pipes-exercise/age.pipe.ts
+++ b/src/app/exercises/pipes-exercise/age.pipe.ts
@@ -1,0 +1,11 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'age', standalone: true })
+export class AgePipe implements PipeTransform {
+  transform(date: Date | string | null | undefined): number {
+    if (!date) return 0;
+    const d = new Date(date);
+    const diff = Date.now() - d.getTime();
+    return Math.floor(diff / (1000 * 60 * 60 * 24 * 365.25));
+  }
+}

--- a/src/app/exercises/pipes-exercise/index.ts
+++ b/src/app/exercises/pipes-exercise/index.ts
@@ -1,0 +1,2 @@
+export * from './to-min-hours.pipe';
+export * from './age.pipe';

--- a/src/app/exercises/pipes-exercise/to-min-hours.pipe.ts
+++ b/src/app/exercises/pipes-exercise/to-min-hours.pipe.ts
@@ -1,0 +1,11 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'toMinHours', standalone: true })
+export class ToMinHoursPipe implements PipeTransform {
+  transform(value: number | null | undefined): string {
+    if (value == null) return '';
+    const hours = Math.floor(value / 60);
+    const minutes = value % 60;
+    return `${hours} hours and ${minutes} minutes`;
+  }
+}

--- a/src/app/exercises/rxjs-exercises/color-game.service.ts
+++ b/src/app/exercises/rxjs-exercises/color-game.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, combineLatest } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class ColorGameService {
+  #red = new BehaviorSubject(0);
+  #green = new BehaviorSubject(0);
+  #blue = new BehaviorSubject(0);
+
+  red$ = this.#red.asObservable();
+  green$ = this.#green.asObservable();
+  blue$ = this.#blue.asObservable();
+
+  color$ = combineLatest([this.red$, this.green$, this.blue$]);
+
+  setRed(v: number) { this.#red.next(v); }
+  setGreen(v: number) { this.#green.next(v); }
+  setBlue(v: number) { this.#blue.next(v); }
+
+  randomizeColor() {
+    this.setRed(Math.floor(Math.random() * 256));
+    this.setGreen(Math.floor(Math.random() * 256));
+    this.setBlue(Math.floor(Math.random() * 256));
+  }
+}

--- a/src/app/exercises/services-exam-exercise/exam.service.ts
+++ b/src/app/exercises/services-exam-exercise/exam.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { Question } from './question.model';
+
+const QUESTIONS: Question[] = [
+  { id: 1, questionText: 'Capital of France?', options: ['Paris','Rome'], correctAnswer: 'Paris' },
+  { id: 2, questionText: '2+2?', options: ['3','4'], correctAnswer: '4' }
+];
+
+@Injectable({ providedIn: 'root' })
+export class ExamService {
+  #questions = new BehaviorSubject<Question[]>(QUESTIONS);
+  questions$ = this.#questions.asObservable();
+
+  answer(id: number, answer: string) {
+    const updated = this.#questions.value.map(q => q.id === id ? { ...q, userAnswer: answer } : q);
+    this.#questions.next(updated);
+  }
+}

--- a/src/app/exercises/services-exam-exercise/question.model.ts
+++ b/src/app/exercises/services-exam-exercise/question.model.ts
@@ -1,0 +1,7 @@
+export interface Question {
+  id: number;
+  questionText: string;
+  options: string[];
+  correctAnswer: string;
+  userAnswer?: string;
+}


### PR DESCRIPTION
## Summary
- add custom directives for `HideAfter` and `ScrollIntoView`
- implement travel form exercise using reactive forms
- create input/output gallery example
- add custom pipes (`toMinHours` and `age`)
- add basic image model service
- provide RxJS color game service
- create exam service exercise
- create movie explorer example with duration pipe

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68484a0693ac8321ac593f7fb530344c