### PR TITLE
Add routes to exercise solutions

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,10 @@
 <!-- <app-upsert-person></app-upsert-person> -->
 
-<app-people-page></app-people-page>
+<nav>
+  <a routerLink="/">People</a> |
+  <a routerLink="/gallery">Gallery</a> |
+  <a routerLink="/travel-form">Travel Form</a> |
+  <a routerLink="/movie-list">Movies</a>
+</nav>
+
+<router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,14 +1,10 @@
 import { Component, inject, signal } from '@angular/core';
-import { CounterComponent } from "./components/counter/counter.component";
-import { PersonListComponent } from "./components/person-list/person-list.component";
-import { Person } from './models/person.model';
+import { RouterOutlet, RouterLink } from '@angular/router';
 import { PeopleApiService } from './services/people-api.service';
-import { PeoplePageComponent } from "./pages/people-page/people-page.component";
-import { UpsertPersonComponent } from "./components/upsert-person/upsert-person.component";
 
 @Component({
   selector: 'app-root',
-  imports: [UpsertPersonComponent, PeoplePageComponent],
+  imports: [RouterOutlet, RouterLink],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,12 @@
 import { Routes } from '@angular/router';
+import { PeoplePageComponent } from './pages/people-page/people-page.component';
+import { GalleryComponent } from './exercises/input-output-exercise/gallery.component';
+import { TravelFormComponent } from './exercises/forms-exercise/travel-form.component';
+import { MovieListComponent } from './exercises/movie-explorer-exercise/movie-list.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: '', component: PeoplePageComponent },
+  { path: 'gallery', component: GalleryComponent },
+  { path: 'travel-form', component: TravelFormComponent },
+  { path: 'movie-list', component: MovieListComponent },
+];


### PR DESCRIPTION
## Summary
- expose exercise solution components via router
- display routed content with `<router-outlet>`
- add navigation links for each route

## Testing
- `npm install`
- `npx ng test` *(fails: No Chrome binary)*
- `npx ng build` *(fails: application bundle generation error)*


------
https://chatgpt.com/codex/tasks/task_b_68484bf769e08321a049062969693162