### PR TITLE
Add exam UI with signals

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -3,11 +3,13 @@ import { PeoplePageComponent } from './pages/people-page/people-page.component';
 import { GalleryComponent } from './exercises/input-output-exercise/gallery.component';
 import { TravelFormComponent } from './exercises/forms-exercise/travel-form.component';
 import { MovieListComponent } from './exercises/movie-explorer-exercise/movie-list.component';
+import { ExamComponent } from './exercises/services-exam-exercise/exam.component';
 
 export const routes: Routes = [
   { path: 'People', component: PeoplePageComponent },
   { path: 'gallery', component: GalleryComponent },
   { path: 'travel-form', component: TravelFormComponent },
   { path: 'movie-list', component: MovieListComponent },
+  { path: 'exam', component: ExamComponent },
   { path: '', redirectTo: 'gallery', pathMatch: 'full' }
 ];

--- a/src/app/exercises/services-exam-exercise/exam.component.css
+++ b/src/app/exercises/services-exam-exercise/exam.component.css
@@ -1,0 +1,9 @@
+.exam-container {
+  display: flex;
+  gap: 16px;
+}
+
+.score {
+  margin-top: 16px;
+  font-weight: bold;
+}

--- a/src/app/exercises/services-exam-exercise/exam.component.html
+++ b/src/app/exercises/services-exam-exercise/exam.component.html
@@ -1,0 +1,12 @@
+<div class="exam-container">
+  <app-question-list
+    [questions]="questions()"
+    [selectedId]="selectedId()"
+    (select)="select($event)"></app-question-list>
+
+  <app-question-detail
+    [question]="selectedQuestion()"
+    (answer)="answer($event)"></app-question-detail>
+
+  <div class="score">Score: {{ score() }} / {{ questions().length }}</div>
+</div>

--- a/src/app/exercises/services-exam-exercise/exam.component.ts
+++ b/src/app/exercises/services-exam-exercise/exam.component.ts
@@ -1,0 +1,36 @@
+import { Component, computed, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ExamService } from './exam.service';
+import { QuestionListComponent } from './question-list.component';
+import { QuestionDetailComponent } from './question-detail.component';
+
+@Component({
+  selector: 'app-exam',
+  standalone: true,
+  imports: [CommonModule, QuestionListComponent, QuestionDetailComponent],
+  templateUrl: './exam.component.html',
+  styleUrl: './exam.component.css'
+})
+export class ExamComponent {
+  #service = inject(ExamService);
+  questions = this.#service.questions;
+  score = this.#service.score;
+  selectedId = signal<number | null>(null);
+
+  selectedQuestion = computed(() =>
+    this.questions().find(q => q.id === this.selectedId()) ?? null
+  );
+
+  constructor() {
+    const first = this.questions()[0];
+    if (first) this.selectedId.set(first.id);
+  }
+
+  select(id: number) {
+    this.selectedId.set(id);
+  }
+
+  answer({ id, answer }: { id: number; answer: string }) {
+    this.#service.answer(id, answer);
+  }
+}

--- a/src/app/exercises/services-exam-exercise/exam.service.ts
+++ b/src/app/exercises/services-exam-exercise/exam.service.ts
@@ -1,5 +1,4 @@
-import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { Injectable, computed, signal } from '@angular/core';
 import { Question } from './question.model';
 
 const QUESTIONS: Question[] = [
@@ -9,11 +8,19 @@ const QUESTIONS: Question[] = [
 
 @Injectable({ providedIn: 'root' })
 export class ExamService {
-  #questions = new BehaviorSubject<Question[]>(QUESTIONS);
-  questions$ = this.#questions.asObservable();
+  #questions = signal<Question[]>(QUESTIONS);
+
+  questions = this.#questions.asReadonly();
+
+  score = computed(() =>
+    this.#questions()
+      .filter(q => q.userAnswer && q.userAnswer === q.correctAnswer)
+      .length
+  );
 
   answer(id: number, answer: string) {
-    const updated = this.#questions.value.map(q => q.id === id ? { ...q, userAnswer: answer } : q);
-    this.#questions.next(updated);
+    this.#questions.update(qs =>
+      qs.map(q => (q.id === id ? { ...q, userAnswer: answer } : q))
+    );
   }
 }

--- a/src/app/exercises/services-exam-exercise/question-detail.component.css
+++ b/src/app/exercises/services-exam-exercise/question-detail.component.css
@@ -1,0 +1,18 @@
+.detail {
+  flex: 1;
+}
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+.options button.selected {
+  background: #eef;
+}
+.correct {
+  color: green;
+}
+.incorrect {
+  color: red;
+}

--- a/src/app/exercises/services-exam-exercise/question-detail.component.html
+++ b/src/app/exercises/services-exam-exercise/question-detail.component.html
@@ -1,0 +1,18 @@
+<div *ngIf="question() as q" class="detail">
+  <h3>{{ q.questionText }}</h3>
+  <div class="options">
+    @for(option of q.options; track option)
+    {
+      <button
+        (click)="choose(option)"
+        [disabled]="!!q.userAnswer"
+        [class.selected]="q.userAnswer === option">
+        {{ option }}
+      </button>
+    }
+  </div>
+  <p *ngIf="q.userAnswer" [class.correct]="q.userAnswer === q.correctAnswer" [class.incorrect]="q.userAnswer !== q.correctAnswer">
+    You answered: {{ q.userAnswer }} - {{ q.userAnswer === q.correctAnswer ? 'Correct' : 'Incorrect' }}
+  </p>
+</div>
+<div *ngIf="!question()">Select a question</div>

--- a/src/app/exercises/services-exam-exercise/question-detail.component.ts
+++ b/src/app/exercises/services-exam-exercise/question-detail.component.ts
@@ -1,0 +1,22 @@
+import { Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Question } from './question.model';
+
+@Component({
+  selector: 'app-question-detail',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './question-detail.component.html',
+  styleUrl: './question-detail.component.css'
+})
+export class QuestionDetailComponent {
+  question = input<Question | null>(null);
+  answer = output<{ id: number; answer: string }>();
+
+  choose(option: string) {
+    const q = this.question();
+    if (q) {
+      this.answer.emit({ id: q.id, answer: option });
+    }
+  }
+}

--- a/src/app/exercises/services-exam-exercise/question-list.component.css
+++ b/src/app/exercises/services-exam-exercise/question-list.component.css
@@ -1,0 +1,22 @@
+.question-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 120px;
+}
+.question-list li {
+  padding: 4px 8px;
+  cursor: pointer;
+  border: 1px solid #ccc;
+}
+.question-list li.selected {
+  background: #eef;
+}
+.question-list li.correct {
+  border-color: green;
+}
+.question-list li.incorrect {
+  border-color: red;
+}

--- a/src/app/exercises/services-exam-exercise/question-list.component.html
+++ b/src/app/exercises/services-exam-exercise/question-list.component.html
@@ -1,0 +1,12 @@
+<ul class="question-list">
+  @for(q of questions(); track q.id)
+  {
+    <li
+      (click)="select.emit(q.id)"
+      [class.selected]="selectedId() === q.id"
+      [class.correct]="q.userAnswer && q.userAnswer === q.correctAnswer"
+      [class.incorrect]="q.userAnswer && q.userAnswer !== q.correctAnswer">
+      {{ q.id }}
+    </li>
+  }
+</ul>

--- a/src/app/exercises/services-exam-exercise/question-list.component.ts
+++ b/src/app/exercises/services-exam-exercise/question-list.component.ts
@@ -1,0 +1,16 @@
+import { Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Question } from './question.model';
+
+@Component({
+  selector: 'app-question-list',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './question-list.component.html',
+  styleUrl: './question-list.component.css'
+})
+export class QuestionListComponent {
+  questions = input<Question[]>([]);
+  selectedId = input<number | null>(null);
+  select = output<number>();
+}


### PR DESCRIPTION
## Summary
- implement exam service using signals
- create exam component and child components for questions
- show question list, question detail, and score
- add route for the new exam component

## Testing
- `npm test --silent -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_684857cbb9b48321b300124975d01eb8